### PR TITLE
Fix KSP build errors

### DIFF
--- a/app/src/main/java/com/example/struku/data/local/converter/DateConverter.kt
+++ b/app/src/main/java/com/example/struku/data/local/converter/DateConverter.kt
@@ -20,6 +20,6 @@ class DateConverter {
      */
     @TypeConverter
     fun toDate(timestamp: Long?): Date? {
-        return timestamp?.let { Date(it) }
+        return if (timestamp != null && timestamp > 0) Date(timestamp) else null
     }
 }

--- a/app/src/main/java/com/example/struku/data/mapper/ReceiptMapper.kt
+++ b/app/src/main/java/com/example/struku/data/mapper/ReceiptMapper.kt
@@ -24,11 +24,11 @@ class ReceiptMapper @Inject constructor() {
             merchantName = receipt.merchantName,
             date = receipt.date,
             total = receipt.total,
-            currency = receipt.currency ?: "IDR",
+            currency = receipt.currency,
             category = receipt.category,
             imageUri = receipt.imageUri,
-            notes = receipt.notes,
-            createdAt = receipt.createdAt ?: Date(),
+            notes = receipt.notes.takeIf { it.isNotBlank() },
+            createdAt = receipt.createdAt,
             updatedAt = Date() // Always use current time for updates
         )
     }
@@ -83,7 +83,7 @@ class ReceiptMapper @Inject constructor() {
             quantity = lineItem.quantity,
             total = lineItem.price * lineItem.quantity,
             category = lineItem.category,
-            notes = lineItem.notes
+            notes = lineItem.notes.takeIf { it.isNotBlank() }
         )
     }
 

--- a/app/src/main/java/com/example/struku/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/struku/di/RepositoryModule.kt
@@ -1,5 +1,6 @@
 package com.example.struku.di
 
+import android.content.Context
 import com.example.struku.data.local.dao.ReceiptDao
 import com.example.struku.data.mapper.ReceiptMapper
 import com.example.struku.data.ocr.AdvancedImagePreprocessor
@@ -12,6 +13,7 @@ import com.example.struku.domain.repository.ReceiptRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
@@ -40,11 +42,12 @@ object RepositoryModule {
     @Provides
     @Singleton
     fun provideOcrRepository(
+        @ApplicationContext context: Context,
         ocrEngine: MlKitOcrEngine,
         imagePreprocessor: AdvancedImagePreprocessor,
         receiptParser: ReceiptParser
     ): OcrRepository {
-        return OcrRepositoryImpl(ocrEngine, imagePreprocessor, receiptParser)
+        return OcrRepositoryImpl(context, ocrEngine, imagePreprocessor, receiptParser)
     }
     
     /**


### PR DESCRIPTION
This PR fixes the build failures related to KSP and Room database generation:

1. Fixed `DateConverter` implementation with proper null handling
2. Enhanced `OcrRepositoryImpl` with correct implementation of `scanReceipt` and `saveReceiptImage` methods
3. Updated `RepositoryModule` to inject `ApplicationContext` correctly
4. Fixed entity and domain model classes with proper null handling and @RawValue annotations for Parcelize
5. Ensured proper TypeConverter annotations across the codebase

The errors were primarily related to:
- ArrayIndexOutOfBoundsException in KSP during annotation processing
- Compilation error in the Kotlin Gradle task

These fixes should resolve the build errors and allow the app to compile successfully.